### PR TITLE
Preview upcoming periods & fix periods with suffixes

### DIFF
--- a/src/lib/dateFormat.ts
+++ b/src/lib/dateFormat.ts
@@ -36,7 +36,7 @@ const getDuration = (future: number) => {
 	const now = time.getTime() / 1000;
 	const timeLeft = Math.floor(future - now);
 	const hours = Math.floor(timeLeft / 60 / 60);
-	const minutes = Math.ceil((timeLeft / 60) % 60);
+	const minutes = dev ? Math.floor((timeLeft / 60) % 60) : Math.ceil((timeLeft / 60) % 60);
 	const seconds = timeLeft % 60;
 	const suffix = dev ? ` ${seconds}s` : ''; // only show seconds in dev mode
 
@@ -49,6 +49,10 @@ export const getPeriodText = (period: Period) => {
 	} else if (period.kind === 'AfterSchool') {
 		return "School's out!";
 	} else {
-		return `${period.friendly_name} ends in ${getDuration(period.end_timestamp)}`;
+		if (period.start_timestamp < time.getTime() / 1000) {
+			return `${period.friendly_name} ends in ${getDuration(period.end_timestamp)}`;
+		} else {
+			return `${period.friendly_name} starts in ${getDuration(period.start_timestamp)}`;
+		}
 	}
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Removes a "suffix" from the name of a period, if one exists.
+ * ex: `Block 5A` becomes `Block 5`
+ */
+export function stripPeriodSuffix(periodName: string) {
+	const match = /^.+ \d[A-Za-z]$/.test(periodName);
+	return match ? periodName.slice(0, -1) : periodName;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,31 @@
 <script lang="ts">
+	import type { CurrentPeriodsState } from '$lib/components/DataLoader.svelte';
+	import { getContext } from 'svelte';
+
 	import Legend from '$lib/components/Legend.svelte';
-	import TimeInfo from './TimeInfo.svelte';
+	import TimeInfo, { selected } from './TimeInfo.svelte';
 	import LocationsAdapter from './LocationsAdapter.svelte';
 	import BannerNotification from '$lib/components/BannerNotification.svelte';
+
+	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
+	const periods = $derived({
+		current: currentPeriods?.state.current || [],
+		future: currentPeriods?.state.future || [],
+	});
+
+	const activePeriods = $derived.by(() => {
+		if (selected.state === 'current') {
+			let periodsShown = [...periods.current];
+			if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
+				periodsShown.push(...periods.future);
+			}
+
+			return periodsShown;
+		} else {
+			return [selected.state];
+		}
+	});
+	$inspect(activePeriods);
 </script>
 
 <svelte:head>
@@ -12,10 +35,10 @@
 <div
 	class="flex flex-col not-supports-[height:100dvh]:h-screen supports-[height:100dvh]:h-dvh sm:flex-row"
 >
-	<TimeInfo />
+	<TimeInfo {activePeriods} />
 	<div class="flex h-full flex-col overflow-y-auto sm:w-3/4">
 		<BannerNotification canDismiss />
-		<main class="grow"><LocationsAdapter /></main>
+		<main class="grow"><LocationsAdapter {activePeriods} /></main>
 		<footer
 			class="h-small:visible 2k:py-8 invisible sticky bottom-0 flex items-center justify-center bg-gray-300 py-4"
 		>

--- a/src/routes/LocationsAdapter.svelte
+++ b/src/routes/LocationsAdapter.svelte
@@ -14,23 +14,23 @@
 	const peDataContext = getContext('board-data') as PEDataState | undefined;
 	const peData = $derived(peDataContext?.state.data || []);
 
-	const periodNames = $derived.by(() => {
+	const activePeriods = $derived.by(() => {
 		if (selected.state === 'current') {
 			let periodsShown = [...periods.current];
 			if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
 				periodsShown.push(...periods.future);
 			}
 
-			return periodsShown.map((p) => p.friendly_name);
+			return periodsShown;
 		} else {
-			return [selected.state.friendly_name];
+			return [selected.state];
 		}
 	});
-	$inspect(periodNames);
+	$inspect(activePeriods);
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];
-		const normalizedPeriodNames = periodNames.map(stripPeriodSuffix);
+		const normalizedPeriodNames = activePeriods.map((p) => p.friendly_name).map(stripPeriodSuffix);
 		for (const teacher of peData) {
 			// 1. Get current classes for each teacher
 			// 2. Exclude periods not listed in the spreadsheet data

--- a/src/routes/LocationsAdapter.svelte
+++ b/src/routes/LocationsAdapter.svelte
@@ -1,32 +1,17 @@
 <script lang="ts">
-	import type { CurrentPeriodsState, PEDataState } from '$lib/components/DataLoader.svelte';
+	import type { PEDataState } from '$lib/components/DataLoader.svelte';
+	import type { Period } from '$lib/api';
 	import { getContext } from 'svelte';
-	import { selected } from './TimeInfo.svelte';
 	import { stripPeriodSuffix } from '$lib/utils';
 	import ClassLocations from '$lib/components/ClassLocations.svelte';
 
-	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
-	const periods = $derived({
-		current: currentPeriods?.state.current || [],
-		future: currentPeriods?.state.future || [],
-	});
+	interface Props {
+		activePeriods: Period[];
+	}
+	const { activePeriods }: Props = $props();
 
 	const peDataContext = getContext('board-data') as PEDataState | undefined;
 	const peData = $derived(peDataContext?.state.data || []);
-
-	const activePeriods = $derived.by(() => {
-		if (selected.state === 'current') {
-			let periodsShown = [...periods.current];
-			if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
-				periodsShown.push(...periods.future);
-			}
-
-			return periodsShown;
-		} else {
-			return [selected.state];
-		}
-	});
-	$inspect(activePeriods);
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];

--- a/src/routes/LocationsAdapter.svelte
+++ b/src/routes/LocationsAdapter.svelte
@@ -1,30 +1,41 @@
 <script lang="ts">
 	import type { CurrentPeriodsState, PEDataState } from '$lib/components/DataLoader.svelte';
 	import { getContext } from 'svelte';
-	import ClassLocations from '$lib/components/ClassLocations.svelte';
 	import { selected } from './TimeInfo.svelte';
+	import { stripPeriodSuffix } from '$lib/utils';
+	import ClassLocations from '$lib/components/ClassLocations.svelte';
 
 	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
-	const periods = $derived(currentPeriods?.state.current || []);
+	const periods = $derived({
+		current: currentPeriods?.state.current || [],
+		future: currentPeriods?.state.future || [],
+	});
 
 	const peDataContext = getContext('board-data') as PEDataState | undefined;
 	const peData = $derived(peDataContext?.state.data || []);
 
 	const periodNames = $derived.by(() => {
 		if (selected.state === 'current') {
-			return periods.map((period) => period.friendly_name);
+			let periodsShown = [...periods.current];
+			if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
+				periodsShown.push(...periods.future);
+			}
+
+			return periodsShown.map((p) => p.friendly_name);
 		} else {
 			return [selected.state.friendly_name];
 		}
 	});
+	$inspect(periodNames);
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];
+		const normalizedPeriodNames = periodNames.map(stripPeriodSuffix);
 		for (const teacher of peData) {
 			// 1. Get current classes for each teacher
 			// 2. Exclude periods not listed in the spreadsheet data
 			// 3. Also exclude classes where the location is blank or empty
-			const currentClasses = periodNames
+			const currentClasses = normalizedPeriodNames
 				.map((period) => ({
 					teacher: teacher.name,
 					period,

--- a/src/routes/LocationsAdapter.svelte
+++ b/src/routes/LocationsAdapter.svelte
@@ -15,12 +15,17 @@
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];
-		const normalizedPeriodNames = activePeriods.map((p) => p.friendly_name).map(stripPeriodSuffix);
+
+		// using a Set ensures periods are unique
+		const normalizedPeriodNames = new Set(
+			activePeriods.map((p) => p.friendly_name).map(stripPeriodSuffix)
+		);
+
 		for (const teacher of peData) {
 			// 1. Get current classes for each teacher
 			// 2. Exclude periods not listed in the spreadsheet data
 			// 3. Also exclude classes where the location is blank or empty
-			const currentClasses = normalizedPeriodNames
+			const currentClasses = Array.from(normalizedPeriodNames)
 				.map((period) => ({
 					teacher: teacher.name,
 					period,

--- a/src/routes/TimeInfo.svelte
+++ b/src/routes/TimeInfo.svelte
@@ -8,10 +8,15 @@
 </script>
 
 <script lang="ts">
-	import type { ScheduleDataState, CurrentPeriodsState } from '$lib/components/DataLoader.svelte';
+	import type { ScheduleDataState } from '$lib/components/DataLoader.svelte';
 	import { getContext } from 'svelte';
 	import { prettyDate, getPeriodText } from '$lib/dateFormat';
 	import { time } from '$lib/sharedTime.svelte';
+
+	interface Props {
+		activePeriods: Period[];
+	}
+	const { activePeriods }: Props = $props();
 
 	const scheduleData = getContext('current-schedule') as ScheduleDataState | undefined;
 	const scheduledPeriods = $derived.by(() => {
@@ -22,9 +27,6 @@
 			typeof period.kind === 'string' ? period.kind === 'AMSupport' : true
 		);
 	});
-
-	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
-	const periods = $derived(currentPeriods?.state.current || []);
 </script>
 
 <div class="h-auto text-center sm:h-full sm:w-1/4">
@@ -57,7 +59,7 @@
 			{/each}
 		</select>
 		<div class="2k:text-5xl text-xl text-white">
-			{#each periods as period}
+			{#each activePeriods as period}
 				<p>{getPeriodText(period)}</p>
 			{/each}
 		</div>

--- a/src/routes/tv/LocationsAdapter.svelte
+++ b/src/routes/tv/LocationsAdapter.svelte
@@ -15,12 +15,17 @@
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];
-		const normalizedPeriodNames = activePeriods.map((p) => p.friendly_name).map(stripPeriodSuffix);
+
+		// using a Set ensures periods are unique
+		const normalizedPeriodNames = new Set(
+			activePeriods.map((p) => p.friendly_name).map(stripPeriodSuffix)
+		);
+
 		for (const teacher of peData) {
 			// 1. Get current classes for each teacher
 			// 2. Exclude periods not listed in the spreadsheet data
 			// 3. Also exclude classes where the location is blank or empty
-			const currentClasses = normalizedPeriodNames
+			const currentClasses = Array.from(normalizedPeriodNames)
 				.map((period) => ({
 					teacher: teacher.name,
 					period,

--- a/src/routes/tv/LocationsAdapter.svelte
+++ b/src/routes/tv/LocationsAdapter.svelte
@@ -13,19 +13,19 @@
 	const peDataContext = getContext('board-data') as PEDataState | undefined;
 	const peData = $derived(peDataContext?.state.data || []);
 
-	const periodNames = $derived.by(() => {
+	const activePeriods = $derived.by(() => {
 		let periodsShown = [...periods.current];
 		if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
 			periodsShown.push(...periods.future);
 		}
 
-		return periodsShown.map((p) => p.friendly_name);
+		return periodsShown;
 	});
-	$inspect(periodNames);
+	$inspect(activePeriods);
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];
-		const normalizedPeriodNames = periodNames.map(stripPeriodSuffix);
+		const normalizedPeriodNames = activePeriods.map((p) => p.friendly_name).map(stripPeriodSuffix);
 		for (const teacher of peData) {
 			// 1. Get current classes for each teacher
 			// 2. Exclude periods not listed in the spreadsheet data

--- a/src/routes/tv/LocationsAdapter.svelte
+++ b/src/routes/tv/LocationsAdapter.svelte
@@ -1,27 +1,17 @@
 <script lang="ts">
-	import type { CurrentPeriodsState, PEDataState } from '$lib/components/DataLoader.svelte';
+	import type { PEDataState } from '$lib/components/DataLoader.svelte';
+	import type { Period } from '$lib/api';
 	import { getContext } from 'svelte';
 	import { stripPeriodSuffix } from '$lib/utils';
 	import ClassLocations from '$lib/components/ClassLocations.svelte';
 
-	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
-	const periods = $derived({
-		current: currentPeriods?.state.current || [],
-		future: currentPeriods?.state.future || [],
-	});
+	interface Props {
+		activePeriods: Period[];
+	}
+	const { activePeriods }: Props = $props();
 
 	const peDataContext = getContext('board-data') as PEDataState | undefined;
 	const peData = $derived(peDataContext?.state.data || []);
-
-	const activePeriods = $derived.by(() => {
-		let periodsShown = [...periods.current];
-		if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
-			periodsShown.push(...periods.future);
-		}
-
-		return periodsShown;
-	});
-	$inspect(activePeriods);
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];

--- a/src/routes/tv/LocationsAdapter.svelte
+++ b/src/routes/tv/LocationsAdapter.svelte
@@ -1,23 +1,36 @@
 <script lang="ts">
 	import type { CurrentPeriodsState, PEDataState } from '$lib/components/DataLoader.svelte';
 	import { getContext } from 'svelte';
+	import { stripPeriodSuffix } from '$lib/utils';
 	import ClassLocations from '$lib/components/ClassLocations.svelte';
 
 	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
-	const periods = $derived(currentPeriods?.state.current || []);
+	const periods = $derived({
+		current: currentPeriods?.state.current || [],
+		future: currentPeriods?.state.future || [],
+	});
 
 	const peDataContext = getContext('board-data') as PEDataState | undefined;
 	const peData = $derived(peDataContext?.state.data || []);
 
-	const periodNames = $derived(periods.map((period) => period.friendly_name));
+	const periodNames = $derived.by(() => {
+		let periodsShown = [...periods.current];
+		if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
+			periodsShown.push(...periods.future);
+		}
+
+		return periodsShown.map((p) => p.friendly_name);
+	});
+	$inspect(periodNames);
 
 	const displayedLocations = $derived.by(() => {
 		let allLocations = [];
+		const normalizedPeriodNames = periodNames.map(stripPeriodSuffix);
 		for (const teacher of peData) {
 			// 1. Get current classes for each teacher
 			// 2. Exclude periods not listed in the spreadsheet data
 			// 3. Also exclude classes where the location is blank or empty
-			const currentClasses = periodNames
+			const currentClasses = normalizedPeriodNames
 				.map((period) => ({
 					teacher: teacher.name,
 					period,

--- a/src/routes/tv/TimeInfo.svelte
+++ b/src/routes/tv/TimeInfo.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-	import type { ScheduleDataState, CurrentPeriodsState } from '$lib/components/DataLoader.svelte';
+	import type { ScheduleDataState } from '$lib/components/DataLoader.svelte';
+	import type { Period } from '$lib/api';
 	import { getContext } from 'svelte';
 	import { prettyDate, getPeriodText } from '$lib/dateFormat';
 	import { time } from '$lib/sharedTime.svelte';
+
+	interface Props {
+		activePeriods: Period[];
+	}
+	const { activePeriods }: Props = $props();
 
 	const scheduleData = getContext('current-schedule') as ScheduleDataState | undefined;
 	const todayInfo = $derived.by(() => {
@@ -24,9 +30,6 @@
 			text: luma > 128 ? 'var(--color-black)' : 'var(--color-white)',
 		};
 	});
-
-	const currentPeriods = getContext('current-periods') as CurrentPeriodsState | undefined;
-	const periods = $derived(currentPeriods?.state.current || []);
 </script>
 
 <header
@@ -46,7 +49,7 @@
 		<h1 class="2k:mt-4 font-bold font-stretch-expanded">{todayInfo.friendly_name}</h1>
 	</div>
 	<div class="2k:text-5xl/normal text-right text-2xl">
-		{#each periods as period}
+		{#each activePeriods as period}
 			<p>{getPeriodText(period)}</p>
 		{/each}
 	</div>


### PR DESCRIPTION
## What
This PR adds support for displaying the upcoming period(s) while it's either during a passing period or before school.  
It also fixes an issue where periods with suffixes (ex: "Block 5A") would not show any locations, which was because the spreadsheet doesn't include these suffixes, so the logic was unable to match the period to any spreadsheet data.
It closes #25 

## Behavior
### Upcoming previews
The behavior here is largely dictated by the new ETHSBell endpoint added for this purpose in codeths/ethsbell-rewrite#113.
The implementation here is fairly simple:
```js
let periodsShown = [...periods.current];
if (periods.current.some((p) => p.kind === 'Passing' || p.kind === 'BeforeSchool')) {
	periodsShown.push(...periods.future);
}
```
In English, that means that we always show the current periods, and we also show the upcoming periods if we're currently in a passing period or it's before school.

## Periods with Suffixes
This implementation is also pretty straightforward:
```ts
/**
 * Removes a "suffix" from the name of a period, if one exists.
 * ex: `Block 5A` becomes `Block 5`
 */
function stripPeriodSuffix(periodName: string) {
	const match = /^.+ \d[A-Za-z]$/.test(periodName);
	return match ? periodName.slice(0, -1) : periodName;
}
```
If a period name ends with a space, then a number, then a letter, we simply remove the last character, which would be the letter (or suffix).